### PR TITLE
Refine thinking UI and fix scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
     }
     /* Hide copy action while streaming */
     .msg.streaming .bubble-actions{display:none !important}
+    .msg.streaming .body{user-select:none}
 
     /* Assistant actions */
     .bubble-actions{
@@ -134,14 +135,12 @@
     }
     .think-pill::after{
       content:"";position:absolute;inset:0;pointer-events:none;
-      background: linear-gradient(90deg, rgba(255,255,255,0) 0%,
-        rgba(255,255,255,.06) 35%, rgba(255,255,255,.18) 50%, rgba(255,255,255,.06) 65%,
-        rgba(255,255,255,0) 100%);
-      transform: translateX(-100%);
-      animation: pillshimmer 1.15s linear infinite;
-      mix-blend-mode: screen;
+      background:linear-gradient(90deg, rgba(255,255,255,.04) 25%, rgba(255,255,255,.12) 50%, rgba(255,255,255,.04) 75%);
+      background-size:200% 100%;
+      animation:pillshimmer 1.15s linear infinite;
+      mix-blend-mode:screen;
     }
-    @keyframes pillshimmer{to{transform:translateX(100%)}}
+    @keyframes pillshimmer{from{background-position:200% 0}to{background-position:-200% 0}}
     .think-pill.think-finished::after{display:none}
     .think-dot{width:6px;height:6px;border-radius:50%;
       background:radial-gradient(60% 120% at 30% 30%, var(--accent-1) 0%, var(--accent-2) 70%);
@@ -149,15 +148,18 @@
     }
     .think-muted{color:var(--muted)}
     /* When open, dock pill to panel */
-    .think-pill.open{border-bottom-left-radius:8px;border-bottom-right-radius:8px}
+    .think-pill.open{
+      width:100%;
+      border-radius:8px 8px 0 0;
+    }
     .think-panel{
-      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:10px;background:#0b101b;
+      display:none;margin-top:0;border:1px solid var(--border);border-radius:0 0 8px 8px;background:#0b101b;
       padding:10px 12px;max-height:280px;overflow:auto;
       /* thoughts are not copiable */
       user-select:none;
     }
     .think-panel.open{
-      display:block;border-top:none;border-top-left-radius:0;border-top-right-radius:0;
+      display:block;border-top:none;
       margin-top:0;
     }
     .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px}
@@ -260,7 +262,6 @@
       <div class="chat-wrap">
         <div id="chat" class="chat" aria-live="polite" aria-label="Chat transcript">
           <div id="messages" class="list"></div>
-          <div id="bottomSentinel"></div>
         </div>
         <div id="jump" class="jump hidden" role="button" aria-label="Jump to latest">Jump to latest</div>
       </div>
@@ -380,7 +381,6 @@
   <script>
     const chatEl = document.getElementById('chat');
     const listEl = document.getElementById('messages');
-    const bottomSentinel = document.getElementById('bottomSentinel');
 
     const promptEl = document.getElementById('prompt');
     const sendBtn = document.getElementById('sendBtn');
@@ -539,19 +539,22 @@
     promptEl.addEventListener('input', autosize); window.addEventListener('load', autosize);
 
     // Robust scroll control
-    const bottomObserver = new IntersectionObserver((entries) => {
-      for (const e of entries) if (e.target === bottomSentinel) {
-        const atBottom = e.isIntersecting; follow = atBottom; jumpBtn.classList.toggle('hidden', atBottom);
-      }
-    }, { root: chatEl, threshold: 1.0, rootMargin: '0px 0px -8px 0px' });
-    bottomObserver.observe(bottomSentinel);
-
+    function atBottom(){
+      return Math.abs(chatEl.scrollHeight - chatEl.scrollTop - chatEl.clientHeight) < 4;
+    }
     chatEl.addEventListener('scroll', () => {
-      const atBottom = Math.abs(chatEl.scrollHeight - chatEl.scrollTop - chatEl.clientHeight) < 4;
-      follow = atBottom; jumpBtn.classList.toggle('hidden', atBottom);
+      follow = atBottom();
+      jumpBtn.classList.toggle('hidden', follow);
     });
-    function scrollToBottomIfFollowing(){ if (!follow) return; requestAnimationFrame(()=>{ chatEl.scrollTop = chatEl.scrollHeight; }); }
-    jumpBtn.addEventListener('click', () => { follow = true; chatEl.scrollTop = chatEl.scrollHeight; jumpBtn.classList.add('hidden'); });
+    function scrollToBottomIfFollowing(){
+      if (!follow) return;
+      chatEl.scrollTop = chatEl.scrollHeight;
+    }
+    jumpBtn.addEventListener('click', () => {
+      follow = true;
+      chatEl.scrollTop = chatEl.scrollHeight;
+      jumpBtn.classList.add('hidden');
+    });
 
     // Health/model lists
     async function checkHealth(){


### PR DESCRIPTION
## Summary
- Smooth the thinking shimmer across the full pill for a unified effect
- Restyle expanded thought panel and block copying during thinking
- Simplify scroll tracking to reliably follow new messages

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6891330016d48323ab94c823ddf35405