### PR TITLE
Refine thinking UI and fix chat scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
       overflow-y:auto;scroll-behavior:smooth;padding:18px 18px 0;
       overscroll-behavior: contain;
     }
+    #bottomSentinel{height:1px;}
 
     /* Welcome overlay */
     .welcome{
@@ -125,23 +126,23 @@
     }
 
     /* Thinking pill + panel */
-    .thinking-bar{display:flex;align-items:center;justify-content:flex-start;margin-bottom:10px}
+    .thinking-bar{display:flex;align-items:center;justify-content:flex-start;margin-bottom:10px;padding-right:110px}
     .think-pill{
       position:relative;display:inline-flex;align-items:center;gap:8px;
       border:1px solid var(--border);background:#0f1729;
       color:var(--text);border-radius:999px;padding:6px 12px;font-size:12px;cursor:pointer;user-select:none;
-      overflow:hidden;
+      white-space:nowrap;
     }
+    .think-pill *, .think-panel *{user-select:none}
     .think-pill::after{
       content:"";position:absolute;inset:0;pointer-events:none;
-      background: linear-gradient(90deg, rgba(255,255,255,0) 0%,
-        rgba(255,255,255,.06) 35%, rgba(255,255,255,.18) 50%, rgba(255,255,255,.06) 65%,
-        rgba(255,255,255,0) 100%);
-      transform: translateX(-100%);
+      background: linear-gradient(120deg, rgba(255,255,255,0) 0%,
+        rgba(255,255,255,.25) 50%, rgba(255,255,255,0) 100%);
+      background-size:200% 100%;
       animation: pillshimmer 1.15s linear infinite;
       mix-blend-mode: screen;
     }
-    @keyframes pillshimmer{to{transform:translateX(100%)}}
+    @keyframes pillshimmer{from{background-position:200% 0} to{background-position:-200% 0}}
     .think-pill.think-finished::after{display:none}
     .think-dot{width:6px;height:6px;border-radius:50%;
       background:radial-gradient(60% 120% at 30% 30%, var(--accent-1) 0%, var(--accent-2) 70%);
@@ -149,9 +150,9 @@
     }
     .think-muted{color:var(--muted)}
     /* When open, dock pill to panel */
-    .think-pill.open{border-bottom-left-radius:8px;border-bottom-right-radius:8px}
+    .think-pill.open{border-radius:8px 8px 0 0}
     .think-panel{
-      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:10px;background:#0b101b;
+      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:8px;background:#0b101b;
       padding:10px 12px;max-height:280px;overflow:auto;
       /* thoughts are not copiable */
       user-select:none;
@@ -160,7 +161,7 @@
       display:block;border-top:none;border-top-left-radius:0;border-top-right-radius:0;
       margin-top:0;
     }
-    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px}
+    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px;user-select:none}
 
     /* Composer */
     .composer{
@@ -543,7 +544,7 @@
       for (const e of entries) if (e.target === bottomSentinel) {
         const atBottom = e.isIntersecting; follow = atBottom; jumpBtn.classList.toggle('hidden', atBottom);
       }
-    }, { root: chatEl, threshold: 1.0, rootMargin: '0px 0px -8px 0px' });
+    }, { root: chatEl, threshold: 0 });
     bottomObserver.observe(bottomSentinel);
 
     chatEl.addEventListener('scroll', () => {
@@ -674,6 +675,7 @@
       ctx.panel.classList.remove('open');
       ctx.pill.classList.remove('open');
       ctx.finished = true;
+      scrollToBottomIfFollowing();
     }
     function formatDuration(ms){
       const s = Math.round(ms/1000);
@@ -810,15 +812,16 @@
             else if (event.type === 'error'){
               appendVisible(msgCtx, `\n\n**[error]** ${event.message}`);
             }
-            else if (event.type === 'done'){
-              // finalize pill if still running
-              const tctx = msgCtx.thinking;
-              if (tctx && !tctx.finished){ tctx.stop = performance.now(); finishThinkingUI(tctx); }
-              msgCtx.msg.classList.remove('streaming');
-              const raw = msgCtx.body.getAttribute('data-raw') || '';
-              history.push({role:'assistant', content: raw});
-              updateCtxHint();
-            }
+              else if (event.type === 'done'){
+                // finalize pill if still running
+                const tctx = msgCtx.thinking;
+                if (tctx && !tctx.finished){ tctx.stop = performance.now(); finishThinkingUI(tctx); }
+                msgCtx.msg.classList.remove('streaming');
+                const raw = msgCtx.body.getAttribute('data-raw') || '';
+                history.push({role:'assistant', content: raw});
+                updateCtxHint();
+                scrollToBottomIfFollowing();
+              }
           }
         }
       } catch(err){


### PR DESCRIPTION
## Summary
- prevent thinking pill from clashing with actions and ensure its label stays visible
- add a defined bottom sentinel and direct scrollTop-based following with final scroll after thinking ends

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6891330016d48323ab94c823ddf35405