### PR TITLE
Refine thinking UI and fix chat scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,23 +125,23 @@
     }
 
     /* Thinking pill + panel */
-    .thinking-bar{display:flex;align-items:center;justify-content:flex-start;margin-bottom:10px}
+    .thinking-bar{display:flex;align-items:center;justify-content:flex-start;margin-bottom:10px;padding-right:80px}
     .think-pill{
       position:relative;display:inline-flex;align-items:center;gap:8px;
       border:1px solid var(--border);background:#0f1729;
       color:var(--text);border-radius:999px;padding:6px 12px;font-size:12px;cursor:pointer;user-select:none;
-      overflow:hidden;
+      overflow:hidden;flex-wrap:wrap;max-width:100%;min-width:0;
     }
+    .think-pill *, .think-panel *{user-select:none}
     .think-pill::after{
       content:"";position:absolute;inset:0;pointer-events:none;
-      background: linear-gradient(90deg, rgba(255,255,255,0) 0%,
-        rgba(255,255,255,.06) 35%, rgba(255,255,255,.18) 50%, rgba(255,255,255,.06) 65%,
-        rgba(255,255,255,0) 100%);
-      transform: translateX(-100%);
+      background: linear-gradient(120deg, rgba(255,255,255,0) 0%,
+        rgba(255,255,255,.25) 50%, rgba(255,255,255,0) 100%);
+      background-size:200% 100%;
       animation: pillshimmer 1.15s linear infinite;
       mix-blend-mode: screen;
     }
-    @keyframes pillshimmer{to{transform:translateX(100%)}}
+    @keyframes pillshimmer{from{background-position:200% 0} to{background-position:-200% 0}}
     .think-pill.think-finished::after{display:none}
     .think-dot{width:6px;height:6px;border-radius:50%;
       background:radial-gradient(60% 120% at 30% 30%, var(--accent-1) 0%, var(--accent-2) 70%);
@@ -149,9 +149,9 @@
     }
     .think-muted{color:var(--muted)}
     /* When open, dock pill to panel */
-    .think-pill.open{border-bottom-left-radius:8px;border-bottom-right-radius:8px}
+    .think-pill.open{border-radius:8px 8px 0 0}
     .think-panel{
-      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:10px;background:#0b101b;
+      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:8px;background:#0b101b;
       padding:10px 12px;max-height:280px;overflow:auto;
       /* thoughts are not copiable */
       user-select:none;
@@ -160,7 +160,7 @@
       display:block;border-top:none;border-top-left-radius:0;border-top-right-radius:0;
       margin-top:0;
     }
-    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px}
+    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px;user-select:none}
 
     /* Composer */
     .composer{
@@ -650,6 +650,7 @@
         const nowOpen = !panel.classList.contains('open');
         panel.classList.toggle('open', nowOpen);
         pill.classList.toggle('open', nowOpen);
+        scrollToBottomIfFollowing();
       });
 
       // nested scroll handling; need non-passive wheel to forward
@@ -674,6 +675,7 @@
       ctx.panel.classList.remove('open');
       ctx.pill.classList.remove('open');
       ctx.finished = true;
+      scrollToBottomIfFollowing();
     }
     function formatDuration(ms){
       const s = Math.round(ms/1000);
@@ -746,6 +748,7 @@
       // thinking UI: auto-open at start
       msgCtx.thinking = createThinkingUI(msgCtx.msg);
       msgCtx.thinking.panel.classList.add('open'); msgCtx.thinking.pill.classList.add('open');
+      scrollToBottomIfFollowing();
 
       // lock UI
       streaming = true; follow = true; setButtonState('pause'); updateCtxHint();
@@ -818,6 +821,7 @@
               const raw = msgCtx.body.getAttribute('data-raw') || '';
               history.push({role:'assistant', content: raw});
               updateCtxHint();
+              scrollToBottomIfFollowing();
             }
           }
         }
@@ -827,6 +831,7 @@
         streaming = false; setButtonState('send');
         if (msgCtx?.thinking && !firstByteAt){ msgCtx.thinking.stop = performance.now(); finishThinkingUI(msgCtx.thinking); }
         msgCtx = null;
+        scrollToBottomIfFollowing();
       }
     }
 


### PR DESCRIPTION
## Summary
- polish thinking pill shimmer to span entire pill and prevent text selection
- simplify open pill/panel styling and avoid copying internal thoughts
- improve scroll handling by keeping chat anchored with sentinel
- fix clipping of "Thought for TIME" and ensure robust autoscroll

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6891330016d48323ab94c823ddf35405