### PR TITLE
Refine thinking UI and fix chat scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,12 +68,11 @@
 
     /* Main layout */
     main{position:relative;display:flex;flex-direction:column;overflow:hidden;}
-    .chat-wrap{flex:1;display:flex;justify-content:center;overflow:hidden;}
+    .chat-wrap{flex:1;overflow-y:auto;scroll-behavior:smooth;overscroll-behavior:contain;}
     .chat{
-      flex:1;max-width:900px;width:100%;
+      max-width:900px;width:100%;margin:0 auto;
       display:flex;flex-direction:column;
-      overflow-y:auto;scroll-behavior:smooth;padding:18px 18px 0;
-      overscroll-behavior: contain;
+      padding:18px 18px 0;
     }
 
     /* Welcome overlay */
@@ -125,23 +124,23 @@
     }
 
     /* Thinking pill + panel */
-    .thinking-bar{display:flex;align-items:center;justify-content:flex-start;margin-bottom:10px}
+    .thinking-bar{display:flex;align-items:center;justify-content:flex-start;margin-bottom:10px;padding-right:80px}
     .think-pill{
       position:relative;display:inline-flex;align-items:center;gap:8px;
       border:1px solid var(--border);background:#0f1729;
       color:var(--text);border-radius:999px;padding:6px 12px;font-size:12px;cursor:pointer;user-select:none;
-      overflow:hidden;
+      overflow:hidden;flex-wrap:wrap;max-width:100%;min-width:0;
     }
+    .think-pill *, .think-panel *{user-select:none}
     .think-pill::after{
       content:"";position:absolute;inset:0;pointer-events:none;
-      background: linear-gradient(90deg, rgba(255,255,255,0) 0%,
-        rgba(255,255,255,.06) 35%, rgba(255,255,255,.18) 50%, rgba(255,255,255,.06) 65%,
-        rgba(255,255,255,0) 100%);
-      transform: translateX(-100%);
+      background: linear-gradient(120deg, rgba(255,255,255,0) 0%,
+        rgba(255,255,255,.25) 50%, rgba(255,255,255,0) 100%);
+      background-size:200% 100%;
       animation: pillshimmer 1.15s linear infinite;
       mix-blend-mode: screen;
     }
-    @keyframes pillshimmer{to{transform:translateX(100%)}}
+    @keyframes pillshimmer{from{background-position:200% 0} to{background-position:-200% 0}}
     .think-pill.think-finished::after{display:none}
     .think-dot{width:6px;height:6px;border-radius:50%;
       background:radial-gradient(60% 120% at 30% 30%, var(--accent-1) 0%, var(--accent-2) 70%);
@@ -149,9 +148,9 @@
     }
     .think-muted{color:var(--muted)}
     /* When open, dock pill to panel */
-    .think-pill.open{border-bottom-left-radius:8px;border-bottom-right-radius:8px}
+    .think-pill.open{border-radius:8px 8px 0 0}
     .think-panel{
-      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:10px;background:#0b101b;
+      display:none;margin-top:0;border:1px dashed #3a4054;border-radius:8px;background:#0b101b;
       padding:10px 12px;max-height:280px;overflow:auto;
       /* thoughts are not copiable */
       user-select:none;
@@ -160,7 +159,7 @@
       display:block;border-top:none;border-top-left-radius:0;border-top-right-radius:0;
       margin-top:0;
     }
-    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px}
+    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px;user-select:none}
 
     /* Composer */
     .composer{
@@ -257,10 +256,10 @@
       <!-- Welcome overlay -->
       <div id="welcome" class="welcome"><div id="welcomeText" class="inner">Welcome back.</div></div>
 
-      <div class="chat-wrap">
-        <div id="chat" class="chat" aria-live="polite" aria-label="Chat transcript">
-          <div id="messages" class="list"></div>
-          <div id="bottomSentinel"></div>
+      <div id="chatWrap" class="chat-wrap" aria-live="polite" aria-label="Chat transcript">
+        <div id="chat" class="chat">
+        <div id="messages" class="list"></div>
+        <div id="bottomSentinel" style="height:1px"></div>
         </div>
         <div id="jump" class="jump hidden" role="button" aria-label="Jump to latest">Jump to latest</div>
       </div>
@@ -378,7 +377,7 @@
   </script>
 
   <script>
-    const chatEl = document.getElementById('chat');
+    const chatEl = document.getElementById('chatWrap');
     const listEl = document.getElementById('messages');
     const bottomSentinel = document.getElementById('bottomSentinel');
 
@@ -539,19 +538,19 @@
     promptEl.addEventListener('input', autosize); window.addEventListener('load', autosize);
 
     // Robust scroll control
-    const bottomObserver = new IntersectionObserver((entries) => {
-      for (const e of entries) if (e.target === bottomSentinel) {
-        const atBottom = e.isIntersecting; follow = atBottom; jumpBtn.classList.toggle('hidden', atBottom);
-      }
-    }, { root: chatEl, threshold: 1.0, rootMargin: '0px 0px -8px 0px' });
-    bottomObserver.observe(bottomSentinel);
-
     chatEl.addEventListener('scroll', () => {
       const atBottom = Math.abs(chatEl.scrollHeight - chatEl.scrollTop - chatEl.clientHeight) < 4;
       follow = atBottom; jumpBtn.classList.toggle('hidden', atBottom);
     });
-    function scrollToBottomIfFollowing(){ if (!follow) return; requestAnimationFrame(()=>{ chatEl.scrollTop = chatEl.scrollHeight; }); }
-    jumpBtn.addEventListener('click', () => { follow = true; chatEl.scrollTop = chatEl.scrollHeight; jumpBtn.classList.add('hidden'); });
+    function scrollToBottomIfFollowing(){
+      if (!follow) return;
+      requestAnimationFrame(()=> bottomSentinel.scrollIntoView({block:'end'}));
+    }
+    jumpBtn.addEventListener('click', () => {
+      follow = true;
+      bottomSentinel.scrollIntoView({block:'end'});
+      jumpBtn.classList.add('hidden');
+    });
 
     // Health/model lists
     async function checkHealth(){
@@ -650,6 +649,7 @@
         const nowOpen = !panel.classList.contains('open');
         panel.classList.toggle('open', nowOpen);
         pill.classList.toggle('open', nowOpen);
+        scrollToBottomIfFollowing();
       });
 
       // nested scroll handling; need non-passive wheel to forward
@@ -674,6 +674,7 @@
       ctx.panel.classList.remove('open');
       ctx.pill.classList.remove('open');
       ctx.finished = true;
+      scrollToBottomIfFollowing();
     }
     function formatDuration(ms){
       const s = Math.round(ms/1000);
@@ -746,6 +747,7 @@
       // thinking UI: auto-open at start
       msgCtx.thinking = createThinkingUI(msgCtx.msg);
       msgCtx.thinking.panel.classList.add('open'); msgCtx.thinking.pill.classList.add('open');
+      scrollToBottomIfFollowing();
 
       // lock UI
       streaming = true; follow = true; setButtonState('pause'); updateCtxHint();
@@ -818,6 +820,7 @@
               const raw = msgCtx.body.getAttribute('data-raw') || '';
               history.push({role:'assistant', content: raw});
               updateCtxHint();
+              scrollToBottomIfFollowing();
             }
           }
         }
@@ -827,6 +830,7 @@
         streaming = false; setButtonState('send');
         if (msgCtx?.thinking && !firstByteAt){ msgCtx.thinking.stop = performance.now(); finishThinkingUI(msgCtx.thinking); }
         msgCtx = null;
+        scrollToBottomIfFollowing();
       }
     }
 


### PR DESCRIPTION
## Summary
- polish thinking pill shimmer to span entire pill and prevent text selection
- simplify open pill/panel styling and avoid copying internal thoughts
- improve scroll handling by keeping chat anchored with sentinel
- fix clipping of "Thought for TIME" and ensure robust autoscroll

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6891330016d48323ab94c823ddf35405