### PR TITLE
feat: add dedicated scrollable chat container

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,10 @@
 
     /* Main layout */
     main{position:relative;display:flex;flex-direction:column;overflow:hidden;}
-    .chat-wrap{flex:1;display:flex;justify-content:center;overflow-y:auto;scroll-behavior:smooth;overscroll-behavior:contain;}
+    .chat-wrap{
+      flex:1;display:flex;flex-direction:column;align-items:center;
+      overflow-y:auto;scroll-behavior:smooth;overscroll-behavior:contain;
+    }
     .chat{
       flex:1;max-width:900px;width:100%;
       display:flex;flex-direction:column;
@@ -163,7 +166,9 @@
 
     /* Composer */
     .composer{
-      position:sticky;bottom:0;padding:18px 16px 24px;background:linear-gradient(180deg, transparent, rgba(10,12,18,.6) 60%, rgba(10,12,18,.85));
+      position:sticky;bottom:0;width:100%;
+      padding:18px 16px 24px;
+      background:linear-gradient(180deg, transparent, rgba(10,12,18,.6) 60%, rgba(10,12,18,.85));
     }
     .dock{
       max-width:900px;margin:0 auto;
@@ -192,7 +197,7 @@
 
     /* Jump to latest */
     .jump{
-      position:absolute;right:24px;bottom:92px;z-index:50;
+      position:sticky;right:24px;bottom:92px;z-index:50;
       background:#0f1729;border:1px solid var(--border);backdrop-filter:blur(10px);
       color:var(--text);padding:8px 12px;border-radius:999px;cursor:pointer;
       box-shadow:var(--shadow);font-size:13px;display:flex;align-items:center;gap:8px
@@ -261,21 +266,21 @@
           <div id="messages" class="list"></div>
         </div>
         <div id="jump" class="jump hidden" role="button" aria-label="Jump to latest">Jump to latest</div>
-      </div>
 
-      <div class="composer">
-        <div class="dock">
-          <div class="left">
-            <div class="attachments" id="attachments"></div>
-            <textarea id="prompt" placeholder="Ask anything…"></textarea>
-          </div>
-          <div class="controls">
-            <button id="sendBtn" type="button" class="btn" aria-label="Send">
-              <svg id="sendIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M22 2L11 13"/>
-                <path d="M22 2l-7 20-4-9-9-4 20-7Z"/>
-              </svg>
-            </button>
+        <div class="composer">
+          <div class="dock">
+            <div class="left">
+              <div class="attachments" id="attachments"></div>
+              <textarea id="prompt" placeholder="Ask anything…"></textarea>
+            </div>
+            <div class="controls">
+              <button id="sendBtn" type="button" class="btn" aria-label="Send">
+                <svg id="sendIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M22 2L11 13"/>
+                  <path d="M22 2l-7 20-4-9-9-4 20-7Z"/>
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -378,6 +383,8 @@
   <script>
     const chatEl = document.getElementById('chatWrap');
     const listEl = document.getElementById('messages');
+    const bottomSentinel = document.createElement('div');
+    listEl.appendChild(bottomSentinel);
 
     const promptEl = document.getElementById('prompt');
     const sendBtn = document.getElementById('sendBtn');
@@ -587,7 +594,7 @@
         actions.appendChild(copyBtn); msg.appendChild(actions);
       }
 
-      wrap.appendChild(msg); listEl.appendChild(wrap); scrollToBottomIfFollowing();
+      wrap.appendChild(msg); listEl.appendChild(wrap); listEl.appendChild(bottomSentinel); scrollToBottomIfFollowing();
       return {wrap, msg, body};
     }
 


### PR DESCRIPTION
## Summary
- embed chat and composer in a single scrollable container
- keep input stuck to bottom while adding sticky jump button
- ensure auto-scroll by appending sentinel after each new message

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68914973c8b0832386c537688a59ff6f