### PR TITLE
Allow page scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
       --msg-max: 780px;
     }
     *{box-sizing:border-box}
-    html,body{height:100%;margin:0;overflow:hidden;}
+    html,body{height:100%;margin:0;overflow:auto;}
     body{
       color:var(--text);
       font:15px/1.55 Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;


### PR DESCRIPTION
## Summary
- enable page scrolling by switching root `overflow:hidden` to `overflow:auto`

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68914e12528c832382744685ce9b8af1