### PR TITLE
fix: anchor header and chat bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
 
     /* Header */
     header{
+      position:sticky;top:0;z-index:100;
       display:grid;grid-template-columns:auto 1fr auto;align-items:center;
       gap:12px;padding:12px 16px;border-bottom:1px solid var(--border);
       backdrop-filter: blur(8px);
@@ -71,6 +72,7 @@
     .chat-wrap{
       flex:1;display:flex;flex-direction:column;align-items:center;
       overflow-y:auto;scroll-behavior:smooth;overscroll-behavior:contain;
+      padding-bottom:160px;
     }
     .chat{
       flex:1;max-width:900px;width:100%;
@@ -166,7 +168,8 @@
 
     /* Composer */
     .composer{
-      position:sticky;bottom:0;width:100%;
+      position:fixed;bottom:0;left:0;right:0;z-index:90;
+      width:auto;
       padding:18px 16px 24px;
       background:linear-gradient(180deg, transparent, rgba(10,12,18,.6) 60%, rgba(10,12,18,.85));
     }


### PR DESCRIPTION
## Summary
- keep header visible by making it sticky with a top offset and z-index
- fix chat composer to viewport bottom and pad chat area to avoid overlap

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689151508c308323b613dd06fbc03286