### PR TITLE
feat: enhance thinking UI and button spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,20 +137,12 @@
       overflow:hidden;flex-wrap:wrap;max-width:100%;min-width:0;
     }
     .think-pill *, .think-panel *{user-select:none}
-    .think-pill::after{
-      content:"";position:absolute;inset:0;pointer-events:none;
-      background: linear-gradient(120deg, rgba(255,255,255,0) 0%,
-        rgba(255,255,255,.25) 50%, rgba(255,255,255,0) 100%);
-      background-size:200% 100%;
-      animation: pillshimmer 1.15s linear infinite;
-      mix-blend-mode: screen;
-    }
-    @keyframes pillshimmer{from{background-position:200% 0} to{background-position:-200% 0}}
-    .think-pill.think-finished::after{display:none}
     .think-dot{width:6px;height:6px;border-radius:50%;
       background:radial-gradient(60% 120% at 30% 30%, var(--accent-1) 0%, var(--accent-2) 70%);
       box-shadow:0 0 16px rgba(125,211,252,.25);
+      animation:pulse 1.2s ease-in-out infinite;
     }
+    @keyframes pulse{0%,100%{opacity:.6;transform:scale(.8);}50%{opacity:1;transform:scale(1);}}
     .think-muted{color:var(--muted)}
     /* When open, dock pill to panel */
     .think-pill.open{border-radius:8px 8px 0 0}
@@ -164,7 +156,8 @@
       display:block;border-top:none;border-top-left-radius:0;border-top-right-radius:0;
       margin-top:0;
     }
-    .think-panel pre{margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px;user-select:none}
+    .think-counter{font-size:12px;color:var(--muted);margin-bottom:6px}
+    .think-panel pre{display:none;margin:0;white-space:pre-wrap;word-wrap:break-word;font-family:var(--mono);font-size:13px;user-select:none}
 
     /* Composer */
     .composer{
@@ -189,14 +182,22 @@
     .controls{display:flex;align-items:center}
     .btn{
       appearance:none;border:1px solid #2b344a;padding:10px;border-radius:50%;cursor:pointer;
-      width:44px;height:44px;display:grid;place-items:center;background:#0f1729
+      width:44px;height:44px;display:grid;place-items:center;background:#0f1729;
+      position:relative;overflow:hidden
     }
+    .btn-icon{display:grid;place-items:center;position:relative;z-index:1;width:100%;height:100%}
     .btn svg{width:18px;height:18px;stroke:var(--text)}
     .btn.accent{
       background: radial-gradient(60% 120% at 30% 30%, var(--accent-1) 0%, var(--accent-2) 70%);
       color:#061019; border-color:transparent;
     }
     .btn.accent svg{stroke:#061019}
+    .btn.loading::before{
+      content:"";position:absolute;inset:4px;border-radius:50%;
+      background:conic-gradient(from 0deg, var(--accent-1), var(--accent-2), var(--accent-1));
+      filter:blur(2px);animation:spin 1s linear infinite;z-index:0;
+    }
+    @keyframes spin{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
 
     /* Jump to latest */
     .jump{
@@ -278,10 +279,12 @@
             </div>
             <div class="controls">
               <button id="sendBtn" type="button" class="btn" aria-label="Send">
-                <svg id="sendIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <path d="M22 2L11 13"/>
-                  <path d="M22 2l-7 20-4-9-9-4 20-7Z"/>
-                </svg>
+                <span class="btn-icon">
+                  <svg id="sendIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M22 2L11 13"/>
+                    <path d="M22 2l-7 20-4-9-9-4 20-7Z"/>
+                  </svg>
+                </span>
               </button>
             </div>
           </div>
@@ -484,10 +487,10 @@
     // Button state
     function setButtonState(state){
       if (state === 'pause') {
-        sendBtn.setAttribute('aria-label','Pause'); sendBtn.classList.add('accent');
+        sendBtn.setAttribute('aria-label','Pause'); sendBtn.classList.add('accent','loading');
         sendIcon.setAttribute('viewBox','0 0 24 24'); sendIcon.innerHTML = '<rect x="6" y="5" width="4" height="14" rx="1.2"></rect><rect x="14" y="5" width="4" height="14" rx="1.2"></rect>';
       } else {
-        sendBtn.setAttribute('aria-label','Send'); sendBtn.classList.remove('accent');
+        sendBtn.setAttribute('aria-label','Send'); sendBtn.classList.remove('accent','loading');
         sendIcon.setAttribute('viewBox','0 0 24 24'); sendIcon.innerHTML = '<path d="M22 2L11 13"></path><path d="M22 2l-7 20-4-9-9-4 20-7Z"></path>';
       }
     }
@@ -634,16 +637,15 @@
       const tbar = msgEl.querySelector('.thinking-bar');
       tbar.innerHTML = '';
       const pill = document.createElement('div'); pill.className = 'think-pill';
-      const dot = document.createElement('span'); dot.className='think-dot'; dot.setAttribute('aria-hidden','true');
-      const label = document.createElement('span'); label.textContent='Thinking.';
-      pill.appendChild(dot); pill.appendChild(label); tbar.appendChild(pill);
+      const spinner = document.createElement('span'); spinner.className='think-dot'; spinner.setAttribute('aria-hidden','true');
+      const label = document.createElement('span'); label.textContent='Reasoning…';
+      pill.appendChild(spinner); pill.appendChild(label); tbar.appendChild(pill);
 
       const panel = document.createElement('div'); panel.className='think-panel';
-      const pre = document.createElement('pre'); pre.textContent=''; panel.appendChild(pre);
+      const counter = document.createElement('div'); counter.className='think-counter'; counter.textContent='tokens: 0';
+      const pre = document.createElement('pre'); pre.textContent='';
+      panel.appendChild(counter); panel.appendChild(pre);
       tbar.appendChild(panel);
-
-      // ellipsis loop
-      let phase = 0; const iv = setInterval(()=>{ phase=(phase+1)%3; label.textContent = 'Thinking' + '.'.repeat(phase+1); }, 500);
 
       // toggle panel
       pill.addEventListener('click', ()=>{
@@ -658,17 +660,15 @@
       touchForwarder(panel, chatEl);
 
       return {
-        pill, label, dot, panel, pre,
-        interval: iv, start: performance.now(), stop: null,
+        pill, label, spinner, panel, pre, counter,
+        start: performance.now(), stop: null,
         inThink:false, sawThinkOpen:false, sawThinkClose:false, finished:false
       };
     }
     function finishThinkingUI(ctx){
       if (!ctx || ctx.finished) return;
-      if (ctx.interval) clearInterval(ctx.interval);
       const ms = (ctx.stop ?? performance.now()) - ctx.start;
-      ctx.pill.classList.add('think-finished'); // remove shimmer
-      ctx.dot.style.opacity = .6;
+      if (ctx.spinner) ctx.spinner.remove();
       ctx.pill.classList.add('think-muted');
       ctx.label.textContent = `Thought for ${formatDuration(ms)}`;
       // collapse by default on finish
@@ -698,8 +698,15 @@
           if (close !== -1 && (open === -1 || close < open)){ i = close + 8; continue; }
         } else {
           const close = delta.indexOf('</think>', i);
-          if (close === -1){ tctx.pre.textContent += delta.slice(i); break; }
-          else { tctx.pre.textContent += delta.slice(i, close); i = close + 8; tctx.inThink = false; tctx.sawThinkClose = true; continue; }
+          if (close === -1){
+            tctx.pre.textContent += delta.slice(i);
+            if (tctx.counter) tctx.counter.textContent = `tokens: ${estimateTokens(tctx.pre.textContent)}`;
+            break;
+          } else {
+            tctx.pre.textContent += delta.slice(i, close);
+            if (tctx.counter) tctx.counter.textContent = `tokens: ${estimateTokens(tctx.pre.textContent)}`;
+            i = close + 8; tctx.inThink = false; tctx.sawThinkClose = true; continue;
+          }
         }
       }
       return out;
@@ -745,9 +752,8 @@
       startAt = performance.now(); firstByteAt = 0; lastOutTokenEstimate = 0;
       updateTelemetry(estimateTokens(userContent));
 
-      // thinking UI: auto-open at start
+      // thinking UI
       msgCtx.thinking = createThinkingUI(msgCtx.msg);
-      msgCtx.thinking.panel.classList.add('open'); msgCtx.thinking.pill.classList.add('open');
       scrollToBottomIfFollowing();
 
       // lock UI


### PR DESCRIPTION
## Summary
- replace thinking ellipsis with pulsing dot and "Reasoning…" label
- add token counter in hidden panel and keep it collapsed by default
- show rotating gradient spinner on send button during streaming

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689155a2c9708323b32bca52642c59d5