### PR TITLE
feat: add time-aware welcome messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,10 +537,41 @@
     })();
 
     // Welcome variants
+    // 24 hours x 2 day groups (Mon-Thu vs Fri-Sun) = 48 unique messages
     const WELCOME_VARIANTS = [
-      "Welcome back.","Ready when you are.","What are we building today?","Back at it.","Let’s get to work."
+      { weekday: "Burning the midnight oil? Let's code.", weekend: "Midnight vibes on the weekend. Let's explore." },
+      { weekday: "Still up at 1? Productivity never sleeps.", weekend: "1 AM weekend magic. What's next?" },
+      { weekday: "Quiet 2 AM thoughts fuel sharp ideas.", weekend: "Weekend 2 AM adventures begin here." },
+      { weekday: "3 AM—perfect time for deep focus.", weekend: "Night owls unite, it's 3 AM weekend style." },
+      { weekday: "The 4 AM grind shows real dedication.", weekend: "4 AM weekend calm—let's tinker." },
+      { weekday: "5 AM and already planning? Impressive.", weekend: "Sunrise weekend coding at 5 AM." },
+      { weekday: "Good morning, 6 AM starter. Ready?", weekend: "6 AM weekend spark to start the day." },
+      { weekday: "7 AM sharp. Let's tackle tasks.", weekend: "Ease into your 7 AM weekend with code." },
+      { weekday: "8 AM energy—time to ship features.", weekend: "Weekend 8 AM, fuel up for creative hacks." },
+      { weekday: "9 AM routine: coffee and commits.", weekend: "Casual 9 AM weekend coding session." },
+      { weekday: "10 AM momentum—keep it rolling.", weekend: "Relaxed 10 AM weekend brainstorming." },
+      { weekday: "11 AM checks: progress looks good.", weekend: "Weekend 11 AM flow—follow your curiosity." },
+      { weekday: "High noon—time for bold moves.", weekend: "Weekend noon—mix of rest and build." },
+      { weekday: "1 PM pulse—afternoon productivity.", weekend: "1 PM weekend wanderings in code." },
+      { weekday: "2 PM push—projects await.", weekend: "Weekend 2 PM—what can we create?" },
+      { weekday: "3 PM slump? Not here.", weekend: "Weekend 3 PM—keep the pace light." },
+      { weekday: "4 PM sprint to the finish.", weekend: "Weekend 4 PM—take it easy, iterate slowly." },
+      { weekday: "5 PM wrap-ups and review.", weekend: "5 PM weekend glow—share your ideas." },
+      { weekday: "6 PM—time to polish today's work.", weekend: "Weekend 6 PM—code between bites." },
+      { weekday: "7 PM: perfect for side projects.", weekend: "Weekend 7 PM—relax and experiment." },
+      { weekday: "8 PM evening groove—let's refine.", weekend: "8 PM weekend chill with creativity." },
+      { weekday: "9 PM thoughts before sign-off.", weekend: "Weekend 9 PM—nighttime inspiration." },
+      { weekday: "10 PM wrap—great job today.", weekend: "Weekend 10 PM—late-night tinkering." },
+      { weekday: "11 PM reflections and next steps.", weekend: "Weekend 11 PM—dream up something new." },
     ];
-    function pickWelcome(){ welcomeTextEl.textContent = WELCOME_VARIANTS[Math.floor(Math.random()*WELCOME_VARIANTS.length)]; }
+    function pickWelcome(){
+      const now = new Date();
+      const hour = now.getHours(); // 0-23
+      const day = now.getDay(); // 0=Sunday
+      const isFriSun = (day === 0) || (day >= 5); // Fri-Sun uses weekend message
+      const variant = WELCOME_VARIANTS[hour] || WELCOME_VARIANTS[0];
+      welcomeTextEl.textContent = isFriSun ? variant.weekend : variant.weekday;
+    }
     function hideWelcome(){ welcomeEl.classList.add('hidden'); }
     function showWelcome(){ pickWelcome(); welcomeEl.classList.remove('hidden'); }
 


### PR DESCRIPTION
## Summary
- add 48 unique time and day based welcome messages
- choose weekday or weekend variants depending on day

## Testing
- `python -m py_compile server.py`
- `node - <<'NODE' ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_6891779bc7608323b5173bff748af5ae