### PR TITLE
Remove auto-reload from startup script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,4 +7,5 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
-uvicorn server:app --host 0.0.0.0 --port 8000 --reload
+# Start the application without auto-reload and utilize all CPU cores
+uvicorn server:app --host 0.0.0.0 --port 8000 --workers $(nproc)


### PR DESCRIPTION
## Summary
- run uvicorn without `--reload`
- add dynamic `--workers` to utilize CPU cores

## Testing
- `bash -n start.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892240435b08323b27adb0792f47ddf