### PR TITLE
Disable dynamic context by default and add configurable multiplier

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,9 +360,9 @@
 
     <div class="section">
       <h3>Conversation</h3>
-      <div class="toggle"><span>Dynamic Context</span><input id="dynamicCtx" type="checkbox" checked /></div>
+      <div class="toggle"><span>Dynamic Context</span><input id="dynamicCtx" type="checkbox" /></div>
       <label for="maxCtx">Max Context (tokens)</label>
-      <input id="maxCtx" type="number" value="40000" min="4096" step="1024"/>
+      <input id="maxCtx" type="number" value="8192" min="4096" step="1024"/>
       <label for="numCtx">Static Context (if dynamic off)</label>
       <input id="numCtx" type="number" value="8192" min="2048" step="1024"/>
       <label for="systemPrompt">System Prompt (optional)</label>
@@ -452,6 +452,8 @@
     const numPredictEl = document.getElementById('numPredict');
     const seedEl = document.getElementById('seed');
     const systemPromptEl = document.getElementById('systemPrompt');
+
+    const CTX_MULT = 1.1;
 
     const newChatBtn = document.getElementById('newChat');
     const exportChatBtn = document.getElementById('exportChat');
@@ -753,10 +755,10 @@
     // Token estimate + ctx hint
     function estimateTokens(s){ return Math.ceil((s || '').length / 4); }
     function updateCtxHint(){
-      const settings = { dynamic_ctx: dynamicCtxEl.checked, max_ctx: parseInt(maxCtxEl.value || '40000', 10), num_ctx: parseInt(numCtxEl.value || '8192', 10) };
+      const settings = { dynamic_ctx: dynamicCtxEl.checked, max_ctx: parseInt(maxCtxEl.value || '8192', 10), num_ctx: parseInt(numCtxEl.value || '8192', 10) };
       const joined = history.map(m => `${m.role}: ${m.content}`).join('\n');
       const est = estimateTokens(joined);
-      const num_ctx = settings.dynamic_ctx ? Math.max(4096, Math.min(settings.max_ctx, Math.floor(est * 1.2))) : settings.num_ctx;
+      const num_ctx = settings.dynamic_ctx ? Math.max(4096, Math.min(settings.max_ctx, Math.floor(est * CTX_MULT))) : settings.num_ctx;
       ctxHint.textContent = `ctx: ${settings.dynamic_ctx ? 'auto' : num_ctx} (≈${num_ctx})`;
     }
     function updateTelemetry(inTokensOverride){
@@ -1019,7 +1021,7 @@
 
       const settings = {
         dynamic_ctx: dynamicCtxEl.checked,
-        max_ctx: parseInt(maxCtxEl.value || '40000', 10),
+        max_ctx: parseInt(maxCtxEl.value || '8192', 10),
         num_ctx: parseInt(numCtxEl.value || '8192', 10),
         temperature: parseFloat(temperatureEl.value || '0.9'),
         top_p: parseFloat(topPEl.value || '0.9'),

--- a/server.py
+++ b/server.py
@@ -22,7 +22,8 @@ APP_DIR = os.path.dirname(os.path.abspath(__file__))
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 MODEL = os.getenv("MODEL", "goekdenizguelmez/JOSIEFIED-Qwen3:4b-q5_k_m")
 DEFAULT_NUM_CTX = int(os.getenv("DEFAULT_NUM_CTX", "8192"))
-USER_MAX_CTX = int(os.getenv("USER_MAX_CTX", "40000"))
+USER_MAX_CTX = int(os.getenv("USER_MAX_CTX", "8192"))
+CTX_MULTIPLIER = float(os.getenv("CTX_MULTIPLIER", "1.1"))
 
 app = FastAPI(title="Ollama Chat UI")
 
@@ -51,7 +52,7 @@ def build_options(settings: Dict[str, Any], messages: List[Dict[str, Any]]) -> D
     seed = settings.get("seed") or None
     num_predict = settings.get("num_predict") or None
 
-    dynamic_ctx = bool(settings.get("dynamic_ctx", True))
+    dynamic_ctx = bool(settings.get("dynamic_ctx", False))
     user_max_ctx = int(settings.get("max_ctx", USER_MAX_CTX))
     static_ctx = int(settings.get("num_ctx", DEFAULT_NUM_CTX))
 
@@ -59,7 +60,7 @@ def build_options(settings: Dict[str, Any], messages: List[Dict[str, Any]]) -> D
     est_tokens = estimate_tokens(joined)
 
     if dynamic_ctx:
-        num_ctx = clamp(int(est_tokens * 1.2), 4096, user_max_ctx)
+        num_ctx = clamp(int(est_tokens * CTX_MULTIPLIER), 4096, user_max_ctx)
     else:
         num_ctx = clamp(static_ctx, 2048, user_max_ctx)
 


### PR DESCRIPTION
## Summary
- disable dynamic context by default and limit max context to model-like defaults
- add configurable token estimate multiplier and clamp dynamic context using it
- update UI defaults and logic to reflect new context settings

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68922426606c8323b6af5e084b6cf12d