### PR TITLE
Ensure HTTP/2 client dependency is installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
-httpx==0.27.0
+httpx[http2]==0.27.0
 orjson==3.10.7


### PR DESCRIPTION
## Summary
- include HTTP/2 extras for httpx so the server can create an AsyncClient with `http2=True`

## Testing
- `bash start.sh`

------
https://chatgpt.com/codex/tasks/task_e_689239ba9a988323a9d082c9bc2575f3