### PR TITLE
feat: enable server-side web tools with UI feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,11 +981,17 @@
       // keep scroll inside card
       panel.addEventListener('wheel', (e)=>{ e.stopPropagation(); }, {passive:false});
 
-      return {
+      const ctx = {
         pill, label, spinner, panel, pre, counter,
         start: performance.now(), stop: null,
-        inThink:false, sawThinkOpen:false, sawThinkClose:false, finished:false
+        inThink:false, sawThinkOpen:false, sawThinkClose:false, finished:false,
+        mode:'reason'
       };
+      ctx.setMode = (m) => {
+        ctx.mode = m;
+        ctx.label.textContent = m === 'search' ? 'Searching…' : 'Reasoning…';
+      };
+      return ctx;
     }
     function finishThinkingUI(ctx){
       if (!ctx || ctx.finished) return;
@@ -1117,6 +1123,7 @@
             let event; try{ event = JSON.parse(payload); } catch { continue; }
 
             if (event.type === 'delta'){
+              if (msgCtx?.thinking?.mode === 'search') msgCtx.thinking.setMode('reason');
               if (!gotFirstDelta){
                 gotFirstDelta = true;
                 firstByteAt = performance.now();
@@ -1136,6 +1143,17 @@
               }
 
               appendVisible(msgCtx, visible);
+            }
+            else if (event.type === 'tool_calls'){
+              const tctx = msgCtx.thinking;
+              if (tctx){
+                tctx.setMode('search');
+                for (const tc of event.tool_calls || []){
+                  const name = tc.function?.name || tc.name || 'tool';
+                  tctx.pre.textContent += `\n[tool] ${name}`;
+                }
+                if (tctx.counter) tctx.counter.textContent = `tokens: ${estimateTokens(tctx.pre.textContent)}`;
+              }
             }
             else if (event.type === 'error'){
               appendVisible(msgCtx, `\n\n**[error]** ${event.message}`);

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ fastapi==0.111.0
 uvicorn[standard]==0.30.1
 httpx[http2]==0.27.0
 orjson==3.10.7
+requests==2.32.3
+beautifulsoup4==4.12.3

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,82 @@
+import re
+import urllib.parse
+from typing import List, Dict, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+# Simple in-memory caches to avoid repeating network calls
+_SEARCH_CACHE: Dict[Tuple[str, int], Dict] = {}
+_URL_CACHE: Dict[Tuple[str, int], Dict] = {}
+
+def _ddg_search_html(q: str, k: int = 5) -> List[Dict[str, str]]:
+    """Scrape DuckDuckGo's HTML results and return [{title,url,snippet}, ...]."""
+    headers = {"User-Agent": "Mozilla/5.0"}
+    r = requests.get(
+        "https://duckduckgo.com/html/",
+        params={"q": q},
+        headers=headers,
+        timeout=20,
+    )
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    items = []
+    for res in soup.select("div.result")[:k]:
+        a = res.select_one("a.result__a")
+        if not a:
+            continue
+        href = a.get("href", "")
+        if "uddg=" in href:
+            try:
+                qs = urllib.parse.parse_qs(urllib.parse.urlsplit(href).query)
+                href = urllib.parse.unquote(qs.get("uddg", [href])[0])
+            except Exception:
+                pass
+        snippet_el = res.select_one(".result__snippet")
+        items.append(
+            {
+                "title": a.get_text(" ", strip=True),
+                "url": href,
+                "snippet": snippet_el.get_text(" ", strip=True) if snippet_el else "",
+            }
+        )
+    return items
+
+def _clean_text(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip()
+
+def _open_and_extract(url: str, max_chars: int = 6000) -> Dict[str, str]:
+    """Fetch a URL and return {'title','url','text'} with trimmed, readable text."""
+    headers = {"User-Agent": "Mozilla/5.0"}
+    r = requests.get(url, headers=headers, timeout=25)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    title = soup.title.get_text(strip=True) if soup.title else ""
+    main = soup.find(["article", "main"]) or soup.body or soup
+    parts = []
+    for el in main.find_all(["h1", "h2", "h3", "p", "li"], limit=1200):
+        txt = el.get_text(" ", strip=True)
+        if txt:
+            parts.append(txt)
+    text = _clean_text(" ".join(parts))
+    if len(text) > max_chars:
+        text = text[:max_chars] + " …"
+    return {"title": title, "url": url, "text": text}
+
+def web_search(query: str, k: int = 5) -> Dict:
+    """Search the web for recent or factual info and return top results."""
+    key = (query, k)
+    if key not in _SEARCH_CACHE:
+        results = _ddg_search_html(query, k)
+        _SEARCH_CACHE[key] = {"results": results, "source": "duckduckgo_html"}
+    return _SEARCH_CACHE[key]
+
+def open_url(url: str, max_chars: int = 6000) -> Dict:
+    """Open a URL and return a concise text extract for summarization."""
+    key = (url, max_chars)
+    if key not in _URL_CACHE:
+        page = _open_and_extract(url, max_chars=max_chars)
+        _URL_CACHE[key] = {"page": page}
+    return _URL_CACHE[key]


### PR DESCRIPTION
## Summary
- add `web_search` and `open_url` tool implementations and simple caches
- wire server to expose tool schema, execute tools, and continue conversation
- surface tool activity on the front-end and swap thinking label between reasoning and searching

## Testing
- `python -m py_compile server.py tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68926585814c832390e7dedb0bfd146d