### PR TITLE
feat: make web tools async

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
 httpx[http2]==0.27.0
 orjson==3.10.7
-requests==2.32.3
 beautifulsoup4==4.12.3

--- a/server.py
+++ b/server.py
@@ -237,9 +237,9 @@ async def chat_stream(payload: Dict[str, Any]):
                     args = tc.get("function", {}).get("arguments") or {}
                     try:
                         if name == "web_search":
-                            payload = web_search(args.get("query", ""), int(args.get("k", 5)))
+                            payload = await web_search(args.get("query", ""), int(args.get("k", 5)))
                         elif name == "open_url":
-                            payload = open_url(args["url"], int(args.get("max_chars", 6000)))
+                            payload = await open_url(args["url"], int(args.get("max_chars", 6000)))
                         else:
                             payload = {"error": f"Unknown tool {name}"}
                     except Exception as e:

--- a/tools.py
+++ b/tools.py
@@ -2,24 +2,24 @@ import re
 import urllib.parse
 from typing import List, Dict, Tuple
 
-import requests
+import httpx
 from bs4 import BeautifulSoup
 
 # Simple in-memory caches to avoid repeating network calls
 _SEARCH_CACHE: Dict[Tuple[str, int], Dict] = {}
 _URL_CACHE: Dict[Tuple[str, int], Dict] = {}
 
-def _ddg_search_html(q: str, k: int = 5) -> List[Dict[str, str]]:
+async def _ddg_search_html(q: str, k: int = 5) -> List[Dict[str, str]]:
     """Scrape DuckDuckGo's HTML results and return [{title,url,snippet}, ...]."""
     headers = {"User-Agent": "Mozilla/5.0"}
-    r = requests.get(
-        "https://duckduckgo.com/html/",
-        params={"q": q},
-        headers=headers,
-        timeout=20,
-    )
-    r.raise_for_status()
-    soup = BeautifulSoup(r.text, "html.parser")
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        r = await client.get(
+            "https://duckduckgo.com/html/",
+            params={"q": q},
+            headers=headers,
+        )
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
     items = []
     for res in soup.select("div.result")[:k]:
         a = res.select_one("a.result__a")
@@ -45,12 +45,13 @@ def _ddg_search_html(q: str, k: int = 5) -> List[Dict[str, str]]:
 def _clean_text(s: str) -> str:
     return re.sub(r"\s+", " ", s).strip()
 
-def _open_and_extract(url: str, max_chars: int = 6000) -> Dict[str, str]:
+async def _open_and_extract(url: str, max_chars: int = 6000) -> Dict[str, str]:
     """Fetch a URL and return {'title','url','text'} with trimmed, readable text."""
     headers = {"User-Agent": "Mozilla/5.0"}
-    r = requests.get(url, headers=headers, timeout=25)
-    r.raise_for_status()
-    soup = BeautifulSoup(r.text, "html.parser")
+    async with httpx.AsyncClient(timeout=25.0) as client:
+        r = await client.get(url, headers=headers)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
     for tag in soup(["script", "style", "noscript"]):
         tag.decompose()
     title = soup.title.get_text(strip=True) if soup.title else ""
@@ -65,18 +66,18 @@ def _open_and_extract(url: str, max_chars: int = 6000) -> Dict[str, str]:
         text = text[:max_chars] + " …"
     return {"title": title, "url": url, "text": text}
 
-def web_search(query: str, k: int = 5) -> Dict:
+async def web_search(query: str, k: int = 5) -> Dict:
     """Search the web for recent or factual info and return top results."""
     key = (query, k)
     if key not in _SEARCH_CACHE:
-        results = _ddg_search_html(query, k)
+        results = await _ddg_search_html(query, k)
         _SEARCH_CACHE[key] = {"results": results, "source": "duckduckgo_html"}
     return _SEARCH_CACHE[key]
 
-def open_url(url: str, max_chars: int = 6000) -> Dict:
+async def open_url(url: str, max_chars: int = 6000) -> Dict:
     """Open a URL and return a concise text extract for summarization."""
     key = (url, max_chars)
     if key not in _URL_CACHE:
-        page = _open_and_extract(url, max_chars=max_chars)
+        page = await _open_and_extract(url, max_chars=max_chars)
         _URL_CACHE[key] = {"page": page}
     return _URL_CACHE[key]


### PR DESCRIPTION
## Summary
- replace blocking requests usage with httpx.AsyncClient in tools
- make `web_search` and `open_url` async
- await async tools in streaming chat endpoint

## Testing
- `python -m py_compile tools.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68926cec77948323ba9b9a1fd0f66c44