### PR TITLE
Handle tool calls promptly in streaming chat

### DIFF
--- a/server.py
+++ b/server.py
@@ -212,6 +212,7 @@ async def chat_stream(payload: Dict[str, Any]):
                             if "tool_calls" in data:
                                 tool_calls = data["tool_calls"]
                                 yield DATA + orjson.dumps({"type": "tool_calls", "tool_calls": tool_calls}) + END
+                                break
 
                             if data.get("done"):
                                 metrics = data.get("metrics", {})
@@ -223,6 +224,8 @@ async def chat_stream(payload: Dict[str, Any]):
                                 }
                                 done_payload = {"type": "done", "options": options, "usage": usage}
                                 break
+                        if tool_calls:
+                            break
             except httpx.RequestError as e:
                 yield DATA + orjson.dumps({"type": "error", "message": f"Backend request failed: {e}"}) + END
                 break


### PR DESCRIPTION
## Summary
- break out of streaming loop when `tool_calls` appear so tool handlers run immediately

## Testing
- `python -m py_compile server.py`
- `pytest -q`
- manual tool-call stream test demonstrating immediate `tool_calls` event and tool invocation

------
https://chatgpt.com/codex/tasks/task_e_689273208234832385dcd7b6b0632ef3