### PR TITLE
Inspect tool calls within message object

### DIFF
--- a/server.py
+++ b/server.py
@@ -209,8 +209,8 @@ async def chat_stream(payload: Dict[str, Any]):
                             if isinstance(msg, dict) and "content" in msg:
                                 yield DATA + orjson.dumps({"type": "delta", "delta": msg["content"]}) + END
 
-                            if "tool_calls" in data:
-                                tool_calls = data["tool_calls"]
+                            if isinstance(msg, dict) and "tool_calls" in msg:
+                                tool_calls = msg["tool_calls"]
                                 yield DATA + orjson.dumps({"type": "tool_calls", "tool_calls": tool_calls}) + END
                                 break
 


### PR DESCRIPTION
## Summary
- Ensure tool-call detection checks the `message` payload
- Pass tool calls from the message to existing streaming logic

## Testing
- `python -m py_compile server.py tools.py`
- Mocked streaming test triggering `web_search`

------
https://chatgpt.com/codex/tasks/task_e_68927676d4208323968c182f099f703e