### PR TITLE
Fix unsupported orjson.dumps parameter

### DIFF
--- a/server.py
+++ b/server.py
@@ -252,7 +252,11 @@ async def chat_stream(payload: Dict[str, Any]):
                     convo.append({
                         "role": "tool",
                         "tool_call_id": call_id,
-                        "content": orjson.dumps(payload, ensure_ascii=False).decode(),
+                        # orjson does not support the ensure_ascii parameter used by
+                        # the standard library's json.dumps. By default it outputs
+                        # UTF-8 encoded bytes without escaping non-ascii characters,
+                        # so we can simply call dumps and decode the result.
+                        "content": orjson.dumps(payload).decode(),
                     })
                 continue
 


### PR DESCRIPTION
## Summary
- remove unsupported ensure_ascii argument from orjson.dumps
- add explanation comment for future reference

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689280cc2ef08323811d60212a0e67af