### PR TITLE
feat: expand tool support and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -944,6 +944,24 @@
     }
 
     // Thinking UI
+    const TOOL_LABELS = {
+      reason: 'Reasoning…',
+      web_search: 'Searching…',
+      open_url: 'Fetching page…',
+      eval_expr: 'Evaluating…',
+      execute: 'Running code…',
+      read_file: 'Reading file…',
+      write_file: 'Writing file…',
+      terminal_open: 'Using terminal…',
+      terminal_run: 'Using terminal…',
+      terminal_terminate: 'Using terminal…',
+      notes_write: 'Updating notes…',
+      notes_list: 'Referring to notes…',
+      notes_read: 'Referring to notes…',
+      user_prefs_write: 'Updating preferences…',
+      user_prefs_list: 'Reading preferences…',
+      user_prefs_read: 'Reading preferences…',
+    };
     function createThinkingUI(msgEl){
       const tbar = msgEl.querySelector('.thinking-bar');
       tbar.innerHTML = '';
@@ -985,11 +1003,12 @@
         pill, label, spinner, panel, pre, counter,
         start: performance.now(), stop: null,
         inThink:false, sawThinkOpen:false, sawThinkClose:false, finished:false,
-        mode:'reason'
+        mode:'reason', searchTimer:null
       };
       ctx.setMode = (m) => {
         ctx.mode = m;
-        ctx.label.textContent = m === 'search' ? 'Searching…' : 'Reasoning…';
+        ctx.label.textContent = TOOL_LABELS[m] || TOOL_LABELS.reason;
+        if (m === 'reason' && ctx.searchTimer){ clearTimeout(ctx.searchTimer); ctx.searchTimer=null; }
       };
       return ctx;
     }
@@ -1123,7 +1142,7 @@
             let event; try{ event = JSON.parse(payload); } catch { continue; }
 
             if (event.type === 'delta'){
-              if (msgCtx?.thinking?.mode === 'search') msgCtx.thinking.setMode('reason');
+              if (msgCtx?.thinking && msgCtx.thinking.mode !== 'reason' && msgCtx.thinking.mode !== 'web_search') msgCtx.thinking.setMode('reason');
               if (!gotFirstDelta){
                 gotFirstDelta = true;
                 firstByteAt = performance.now();
@@ -1147,10 +1166,16 @@
             else if (event.type === 'tool_calls'){
               const tctx = msgCtx.thinking;
               if (tctx){
-                tctx.setMode('search');
                 for (const tc of event.tool_calls || []){
                   const name = tc.function?.name || tc.name || 'tool';
                   tctx.pre.textContent += `\n[tool] ${name}`;
+                  tctx.setMode(name);
+                  if (name === 'web_search'){
+                    if (tctx.searchTimer) clearTimeout(tctx.searchTimer);
+                    tctx.searchTimer = setTimeout(()=>{
+                      if (tctx.mode === 'web_search') tctx.setMode('reason');
+                    }, 2000);
+                  }
                 }
                 if (tctx.counter) tctx.counter.textContent = `tokens: ${estimateTokens(tctx.pre.textContent)}`;
               }

--- a/tools.py
+++ b/tools.py
@@ -1,9 +1,11 @@
 import re
 import urllib.parse
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Any
 
 import httpx
 from bs4 import BeautifulSoup
+import subprocess
+
 
 # Simple in-memory caches to avoid repeating network calls
 _SEARCH_CACHE: Dict[Tuple[str, int], Dict] = {}
@@ -93,3 +95,128 @@ async def open_url(url: str, max_chars: int = 6000) -> Dict:
         page = await _open_and_extract(url, max_chars=max_chars)
         _URL_CACHE[key] = {"page": page}
     return _URL_CACHE[key]
+
+
+# ----------------- Local utility tools -----------------
+
+async def eval_expr(expr: str) -> Dict[str, Any]:
+    """Evaluate a Python expression and return the result."""
+    try:
+        # Evaluate with no builtins for a bit of safety
+        result = eval(expr, {"__builtins__": {}})
+        return {"result": repr(result)}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+async def execute(code: str) -> Dict[str, Any]:
+    """Execute a Python code snippet and capture stdout/stderr."""
+    try:
+        proc = subprocess.run(
+            ["python", "-"],
+            input=code,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return {
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "returncode": proc.returncode,
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+async def read_file(path: str) -> Dict[str, Any]:
+    """Read a text file and return its contents."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return {"content": f.read()}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+async def write_file(path: str, contents: str) -> Dict[str, Any]:
+    """Write text to a file."""
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(contents)
+        return {"ok": True}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# Terminal session state (single session for simplicity)
+_TERMINAL_OPEN = False
+
+
+async def terminal_open() -> Dict[str, Any]:
+    """Open a pseudo terminal session."""
+    global _TERMINAL_OPEN
+    _TERMINAL_OPEN = True
+    return {"ok": True}
+
+
+async def terminal_run(cmd: str) -> Dict[str, Any]:
+    """Run a shell command in the terminal session."""
+    if not _TERMINAL_OPEN:
+        return {"error": "terminal not open"}
+    try:
+        proc = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return {
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "returncode": proc.returncode,
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+async def terminal_terminate() -> Dict[str, Any]:
+    """Terminate the pseudo terminal session."""
+    global _TERMINAL_OPEN
+    _TERMINAL_OPEN = False
+    return {"ok": True}
+
+
+# Notes and user preferences storage
+_NOTES: Dict[str, str] = {}
+_USER_PREFS: Dict[str, str] = {}
+
+
+async def notes_write(key: str, content: str) -> Dict[str, Any]:
+    _NOTES[key] = content
+    return {"ok": True}
+
+
+async def notes_list() -> Dict[str, Any]:
+    return {"keys": list(_NOTES.keys())}
+
+
+async def notes_read(key: str) -> Dict[str, Any]:
+    if key in _NOTES:
+        return {"content": _NOTES[key]}
+    return {"error": "not found"}
+
+
+async def user_prefs_write(key: str, content: str) -> Dict[str, Any]:
+    _USER_PREFS[key] = content
+    return {"ok": True}
+
+
+async def user_prefs_list() -> Dict[str, Any]:
+    return {"keys": list(_USER_PREFS.keys())}
+
+
+async def user_prefs_read(key: str) -> Dict[str, Any]:
+    if key in _USER_PREFS:
+        return {"content": _USER_PREFS[key]}
+    return {"error": "not found"}
+


### PR DESCRIPTION
## Summary
- expose new tools including eval, execute, file I/O, terminal control, notes, and user preference management
- register tools with backend and improve default developer prompt
- enhance thinking bubble to show tool-specific labels and keep search indicator visible

## Testing
- `python -m py_compile server.py tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6893653b5d508323bcf54cd2bf7a833c